### PR TITLE
Update React minimum dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "author": "Shota Tamura",
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=15.0.1",
-    "react-dom": ">=15.0.1"
+    "react": "^16.3",
+    "react-dom": "^16.3"
   },
   "dependencies": {
     "css-element-queries": "^1.0.2"


### PR DESCRIPTION
This library requires `React.createRef` which is only available in react ^16.3.  Updated dependencies accordingly