### PR TITLE
Add custom handle feature to V1

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,7 @@
 pre {
   margin-top: 5rem !important;
 }
+
+.customHandle { opacity: 1; border: none; background: transparent; height: 0; overflow: visible; padding: 0; z-index: 1; display: flex; align-items: center;}
+.customHandle::before { content: '😀'; display: block; font-size: 64px; }
+.customHandle:hover::before { content: '🤩'; font-size: 72px; }

--- a/src/App.js
+++ b/src/App.js
@@ -185,6 +185,28 @@ class App extends Component {
           />
           <h5>Position: {this.state.position}</h5>
         </div>
+
+
+        <pre>
+          <code className="language-jsx">
+            {`
+<div style={{ maxWidth: '500px' }}>
+  <ReactCompareImage
+    leftImage="/forest1.jpg"
+    rightImage="/cat2.jpg"
+    handle={<button className="customHandle" />}
+  />
+</div>
+          `}
+          </code>
+        </pre>
+        <div style={{ maxWidth: '500px' }}>
+          <ReactCompareImage
+            leftImage="/forest1.jpg"
+            rightImage="/cat2.jpg"
+            handle={<button className="customHandle" />}
+          />
+        </div>
       </div>
     );
   }

--- a/src/ReactCompareImage.js
+++ b/src/ReactCompareImage.js
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 const propTypes = {
   handleSize: PropTypes.number,
+  handle: PropTypes.node,
   hover: PropTypes.bool,
   leftImage: PropTypes.string.isRequired,
   leftImageCss: PropTypes.object,
@@ -20,6 +21,7 @@ const propTypes = {
 
 const defaultProps = {
   handleSize: 40,
+  handle: undefined,
   hover: false,
   leftImageCss: {},
   leftImageLabel: null,
@@ -34,6 +36,7 @@ const defaultProps = {
 function ReactCompareImage(props) {
   const {
     handleSize,
+    handle,
     hover,
     leftImage,
     leftImageCss,
@@ -237,7 +240,16 @@ function ReactCompareImage(props) {
       height: '100%',
       width: `${sliderLineWidth}px`,
     },
-    handle: {
+    handleCustom: {
+      alignItems: 'center',
+      boxSizing: 'border-box',
+      display: 'flex',
+      flex: '1 0 auto',
+      height: 'auto',
+      justifyContent: 'center',
+      width: 'auto',
+    },
+    handleDefault: {
       alignItems: 'center',
       border: `${sliderLineWidth}px solid ${sliderLineColor}`,
       borderRadius: '100%',
@@ -325,10 +337,16 @@ function ReactCompareImage(props) {
         />
         <div style={styles.slider}>
           <div style={styles.line} />
-          <div style={styles.handle}>
-            <div style={styles.leftArrow} />
-            <div style={styles.rightArrow} />
-          </div>
+          {handle ?
+            <div style={styles.handleCustom}>
+              {handle}
+            </div>
+          :
+            <div style={styles.handleDefault}>
+              <div style={styles.leftArrow} />
+              <div style={styles.rightArrow} />
+            </div>
+          }
           <div style={styles.line} />
         </div>
         {/* labels */}

--- a/src/ReactCompareImage.js
+++ b/src/ReactCompareImage.js
@@ -65,24 +65,16 @@ function ReactCompareImage(props) {
   const leftImageRef = useRef();
 
   useEffect(() => {
-    // re-calculate canvas size when container element size is changed
-    const containerElement = containerRef.current;
-    new ResizeSensor(containerElement, () => {
-      getCanvasWidth();
-    });
-    return () => {
-      ResizeSensor.detach(containerElement);
-    };
-  }, []);
-
-  useEffect(() => {
     // when the left image source is changed
     setLeftImgLoaded(false);
     setCanvasWidth(0);
     // consider the case where loading image is completed immediately
     // due to the cache etc.
     const alreadyDone = leftImageRef.current.complete;
-    alreadyDone && setLeftImgLoaded(true);
+
+    if (alreadyDone) {
+      setLeftImgLoaded(true);
+    }
   }, [leftImage]);
 
   useEffect(() => {
@@ -92,14 +84,93 @@ function ReactCompareImage(props) {
     // consider the case where loading image is completed immediately
     // due to the cache etc.
     const alreadyDone = rightImageRef.current.complete;
-    alreadyDone && setRightImgLoaded(true);
+
+    if (alreadyDone) {
+      setRightImgLoaded(true);
+    }
   }, [rightImage]);
+
+  function getCanvasWidth() {
+    // Image size set as follows.
+    //
+    // 1. right(under) image:
+    //     width  = 100% of container width
+    //     height = auto
+    //
+    // 2. left(over) imaze:
+    //     width  = 100% of container width
+    //     height = right image's height
+    //              (protrudes is hidden by css 'object-fit: hidden')
+    setCanvasWidth(rightImageRef.current.getBoundingClientRect().width);
+  }
+
+  useEffect(() => {
+    // re-calculate canvas size when container element size is changed
+    const containerElement = containerRef.current;
+
+    const resizeSensor = new ResizeSensor(containerElement, () => {
+      getCanvasWidth();
+    });
+
+    return () => {
+      ResizeSensor.detach(containerElement);
+    };
+  }, []);
 
   useEffect(() => {
     if (leftImgLoaded && rightImgLoaded) {
       getCanvasWidth();
     }
   }, [leftImgLoaded, rightImgLoaded]);
+
+  function handleSliding(event) {
+    if (!isSliding) setIsSliding(true);
+
+    const e = event || window.event;
+
+    // Calc Cursor Position from the left edge of the viewport
+    const cursorXfromViewport = e.touches ? e.touches[0].pageX : e.pageX;
+
+    // Calc Cursor Position from the left edge of the window (consider any page scrolling)
+    const cursorXfromWindow = cursorXfromViewport - window.pageXOffset;
+
+    // Calc Cursor Position from the left edge of the image
+    const imagePosition = rightImageRef.current.getBoundingClientRect();
+    let pos = cursorXfromWindow - imagePosition.left;
+
+    // Set minimum and maximum values to prevent the slider from overflowing
+    const minPos = sliderLineWidth / 2;
+    const maxPos = canvasWidth - (sliderLineWidth / 2);
+
+    if (pos < minPos) pos = minPos;
+    if (pos > maxPos) pos = maxPos;
+
+    setSliderPosition(pos / canvasWidth);
+
+    // If there's a callback function, invoke it everytime the slider changes
+    if (onSliderPositionChange) {
+      onSliderPositionChange(pos / canvasWidth);
+    }
+  }
+
+  function startSliding(e) {
+    // Prevent default behavior other than mobile scrolling
+    if (!('touches' in e)) {
+      e.preventDefault();
+    }
+
+    // Slide the image even if you just click or tap (not drag)
+    handleSliding(e);
+
+    window.addEventListener('mousemove', handleSliding); // 07
+    window.addEventListener('touchmove', handleSliding); // 08
+  }
+
+  function finishSliding() {
+    setIsSliding(false);
+    window.removeEventListener('mousemove', handleSliding);
+    window.removeEventListener('touchmove', handleSliding);
+  }
 
   useEffect(() => {
     const containerElement = containerRef.current;
@@ -134,69 +205,6 @@ function ReactCompareImage(props) {
     };
   }, [leftImgLoaded, rightImgLoaded, canvasWidth]);
 
-  function getCanvasWidth() {
-    // Image size set as follows.
-    //
-    // 1. right(under) image:
-    //     width  = 100% of container width
-    //     height = auto
-    //
-    // 2. left(over) imaze:
-    //     width  = 100% of container width
-    //     height = right image's height
-    //              (protrudes is hidden by css 'object-fit: hidden')
-    setCanvasWidth(rightImageRef.current.getBoundingClientRect().width);
-  }
-
-  function startSliding(e) {
-    // Prevent default behavior other than mobile scrolling
-    if (!('touches' in e)) {
-      e.preventDefault();
-    }
-
-    // Slide the image even if you just click or tap (not drag)
-    handleSliding(e);
-
-    window.addEventListener('mousemove', handleSliding); // 07
-    window.addEventListener('touchmove', handleSliding); // 08
-  }
-
-  function finishSliding() {
-    setIsSliding(false);
-    window.removeEventListener('mousemove', handleSliding);
-    window.removeEventListener('touchmove', handleSliding);
-  }
-
-  function handleSliding(event) {
-    if (!isSliding) setIsSliding(true);
-
-    const e = event || window.event;
-
-    // Calc Cursor Position from the left edge of the viewport
-    const cursorXfromViewport = e.touches ? e.touches[0].pageX : e.pageX;
-
-    // Calc Cursor Position from the left edge of the window (consider any page scrolling)
-    const cursorXfromWindow = cursorXfromViewport - window.pageXOffset;
-
-    // Calc Cursor Position from the left edge of the image
-    const imagePosition = rightImageRef.current.getBoundingClientRect();
-    let pos = cursorXfromWindow - imagePosition.left;
-
-    // Set minimum and maximum values ​​to prevent the slider from overflowing
-    const minPos = 0 + sliderLineWidth / 2;
-    const maxPos = canvasWidth - sliderLineWidth / 2;
-
-    if (pos < minPos) pos = minPos;
-    if (pos > maxPos) pos = maxPos;
-
-    setSliderPosition(pos / canvasWidth);
-
-    // If there's a callback function, invoke it everytime the slider changes
-    if (onSliderPositionChange) {
-      onSliderPositionChange(pos / canvasWidth);
-    }
-  }
-
   const styles = {
     container: {
       boxSizing: 'border-box',
@@ -227,7 +235,7 @@ function ReactCompareImage(props) {
       flexDirection: 'column',
       height: '100%',
       justifyContent: 'center',
-      left: canvasWidth * sliderPosition - handleSize / 2 + 'px',
+      left: `${(canvasWidth * sliderPosition) - (handleSize / 2)}px`,
       position: 'absolute',
       top: 0,
       width: `${handleSize}px`,

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -89,4 +89,13 @@ storiesOf('ReactCompareImages', module)
         rightImageLabel="After"
       />
     </div>
+  ))
+  .add('handle', () => (
+    <div style={{ maxWidth: '500px', padding: '30px 0', background: 'gray' }}>
+      <ReactCompareImage
+        leftImage="/forest1.jpg"
+        rightImage="/cat2.jpg"
+        handle={<button>Custom<br/>handle</button>}
+      />
+    </div>
   ));


### PR DESCRIPTION
Was using `react-compare-image` on a project where I needed the ability to add custom handle: a button with a hover effect—one that wouldn't block pointer events for the image comparison. 

(My first approach to getting a custom handle, used the callback function to position the handle as needed, but it was either blocking interactions with `ReactImageCompare`, or when `pointer-events: none` was applied, wasn't getting any `:hover` styling.)

Thought others might need this as well. 

Commit 171cf25 addresses some warnings my linter threw.