### PR TITLE
Fix left image height

### DIFF
--- a/src/ReactCompareImage.jsx
+++ b/src/ReactCompareImage.jsx
@@ -227,7 +227,7 @@ function ReactCompareImage(props) {
     leftImage: {
       clip: `rect(auto, ${containerWidth * sliderPosition}px, auto, auto)`,
       display: 'block',
-      height: '100%', // fit to the height of right(under) image
+      height: 'auto', // fit to the height of right(under) image
       objectFit: 'cover', // protrudes is hidden
       position: 'absolute',
       top: 0,


### PR DESCRIPTION
Fixed styling bug that causes the left image to be taller than the right image. Images now sit at an even height. The bug can be viewed here: https://pensive-almeida-0091f3.netlify.com/