### PR TITLE
Apply CSS clip to both images

### DIFF
--- a/src/ReactCompareImage.jsx
+++ b/src/ReactCompareImage.jsx
@@ -219,8 +219,12 @@ function ReactCompareImage(props) {
       overflow: 'hidden',
     },
     rightImage: {
+      clip: `rect(auto, auto, auto, ${containerWidth * sliderPosition}px)`,
       display: 'block',
       height: 'auto', // Respect the aspect ratio
+      objectFit: 'cover', // protrudes is hidden
+      position: 'absolute',
+      top: 0,
       width: '100%',
       ...rightImageCss,
     },

--- a/src/ReactCompareImage.jsx
+++ b/src/ReactCompareImage.jsx
@@ -63,6 +63,7 @@ function ReactCompareImage(props) {
     sliderPositionPercentage,
   );
   const [containerWidth, setContainerWidth] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
   const [leftImgLoaded, setLeftImgLoaded] = useState(false);
   const [rightImgLoaded, setRightImgLoaded] = useState(false);
   const [isSliding, setIsSliding] = useState(false);
@@ -186,6 +187,13 @@ function ReactCompareImage(props) {
         containerElement.addEventListener('mousedown', startSliding); // 05
         window.addEventListener('mouseup', finishSliding); // 06
       }
+
+      setContainerHeight(
+        Math.max(
+          leftImageRef.current.offsetHeight,
+          rightImageRef.current.offsetHeight,
+        ),
+      );
     }
 
     return () => {
@@ -216,6 +224,7 @@ function ReactCompareImage(props) {
       boxSizing: 'border-box',
       position: 'relative',
       width: '100%',
+      height: `${containerHeight}px`,
       overflow: 'hidden',
     },
     rightImage: {


### PR DESCRIPTION
My employer asked me to come up with a PR that fixes #15, so here it is!  In fact, this fixes an additional issue where the left image cannot have transparency.

For my own website, I use a jQuery plugin called [TwentyTwenty](https://zurb.com/playground/twentytwenty), so I based my solution off of what they were doing.  To start, I had the idea to have not just one side have a clip path applied to it, but rather both sides (which I later found to be what TwentyTwenty does as well).  The only problem is that the clip CSS property only applies to absolutely-positioned elements, which led to the height issue with the container.  I found out that TwentyTwenty dynamically set the container's height to that of the taller image, so the absolute positioning doesn't create any issues.

I've tested this within both a custom app with screenshots, and the default demo app, confirming that it doesn't negatively impact existing behavior.  I've also confirmed that this works properly if the left image is taller.
