### PR TITLE
Fix flickering when changing image

### DIFF
--- a/src/ReactCompareImage.tsx
+++ b/src/ReactCompareImage.tsx
@@ -83,7 +83,9 @@ const ReactCompareImage: React.FC<IProps> = props => {
     const containerElement = containerRef.current;
     const resizeObserver = new ResizeObserver(([entry, ..._]) => {
       const currentContainerWidth = entry.target.getBoundingClientRect().width;
-      setContainerWidth(currentContainerWidth);
+      if (currentContainerWidth !== 0) {
+        setContainerWidth(currentContainerWidth);
+      }
     });
     resizeObserver.observe(containerElement);
 


### PR DESCRIPTION
Hello,

I found a bug when one of the image is changed dynamically.
There is a ResizeObserver event sent with the target getting a width of 0.

It causes the slider to shrink and re-render with a null width (and a null computed height) for a few frames. Adding a condition fix this glitchy visual issue. 